### PR TITLE
fix: Improve ReactNativeScannerView Start Sequence

### DIFF
--- a/ios/ReactNativeScannerView.mm
+++ b/ios/ReactNativeScannerView.mm
@@ -58,7 +58,14 @@ using namespace facebook::react;
 
     _prevLayer.videoGravity = AVLayerVideoGravityResizeAspectFill;
        [_view.layer addSublayer:_prevLayer];
-       [_session startRunning];
+    
+    // Create a dispatch queue.
+    dispatch_queue_t sessionQueue = dispatch_queue_create("session queue", DISPATCH_QUEUE_SERIAL);
+
+    // Use dispatch_async to call the startRunning method on the sessionQueue.
+    dispatch_async(sessionQueue, ^{
+        [self->_session startRunning];
+    });
 
     self.contentView = _view;
   }


### PR DESCRIPTION
This change introduces a dispatch queue for starting the AVCaptureSession (`_session`) asynchronously in the ReactNativeScannerView component. By moving the `_session.startRunning` call to a serial dispatch queue named "session queue", the UI thread is no longer blocked by the session start process, potentially improving the UI responsiveness and performance of the application.