### PR TITLE
feat: Enhancements to ReactNativeScannerView with Camera Release and Flashlight Control

### DIFF
--- a/ios/ReactNativeScannerView.mm
+++ b/ios/ReactNativeScannerView.mm
@@ -58,7 +58,7 @@ using namespace facebook::react;
 
     _prevLayer.videoGravity = AVLayerVideoGravityResizeAspectFill;
        [_view.layer addSublayer:_prevLayer];
-    
+      
     // Create a dispatch queue.
     dispatch_queue_t sessionQueue = dispatch_queue_create("session queue", DISPATCH_QUEUE_SERIAL);
 
@@ -101,6 +101,49 @@ using namespace facebook::react;
   }
 }
 
+- (void)releaseCamera {
+    
+    NSLog(@"%@", @"Release Camera");
+
+    if (_session != nil) {
+      // Stop the session
+      [_session stopRunning];
+
+      // Release the session, input, output, and preview layer
+      _session = nil;
+      _input = nil;
+      _output = nil;
+      _prevLayer = nil;
+        
+    }
+}
+
+- (void)enableFlashlight {
+    if ([_device hasTorch] && [_device isTorchModeSupported:AVCaptureTorchModeOn]) {
+        NSError *error = nil;
+        if ([_device lockForConfiguration:&error]) {
+            [_device setTorchMode:AVCaptureTorchModeOn];
+            [_device unlockForConfiguration];
+        } else {
+            // Handle error
+            NSLog(@"%@", [error localizedDescription]);
+        }
+    }
+}
+
+- (void)disableFlashlight {
+    if ([_device hasTorch] && [_device isTorchModeSupported:AVCaptureTorchModeOff]) {
+        NSError *error = nil;
+        if ([_device lockForConfiguration:&error]) {
+            [_device setTorchMode:AVCaptureTorchModeOff];
+            [_device unlockForConfiguration];
+        } else {
+            // Handle error
+            NSLog(@"%@", [error localizedDescription]);
+        }
+    }
+}
+
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
     [super updateProps:props oldProps:oldProps];
@@ -109,6 +152,10 @@ using namespace facebook::react;
 - (void)updateLayoutMetrics:(const facebook::react::LayoutMetrics &)layoutMetrics oldLayoutMetrics:(const facebook::react::LayoutMetrics &)oldLayoutMetrics{
   [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:oldLayoutMetrics];
   _prevLayer.frame = [_view.layer bounds];
+}
+
+- (void)handleCommand:(nonnull const NSString *)commandName args:(nonnull const NSArray *)args {
+    RCTReactNativeScannerViewHandleCommand(self, commandName, args);
 }
 
 @end


### PR DESCRIPTION
This update introduces significant enhancements to the `ReactNativeScannerView` component within an iOS React Native application. Key additions include:

- A new method `releaseCamera` to properly release the camera resources when they are no longer needed. This method stops the camera session and sets the session, input, output, and preview layer references to nil, ensuring that the camera is correctly released and can be used by other applications or instances.

- Two methods, `enableFlashlight` and `disableFlashlight`, have been added to control the device's flashlight. These methods check if the device has a torch and if the torch mode is supported. If so, they lock the device for configuration, set the torch mode to either on or off, and then unlock the device. Error handling is included to log any issues encountered during this process.

- An additional method `handleCommand` is introduced to handle commands for the `ReactNativeScannerView`. This method delegates command handling to the `RCTReactNativeScannerViewHandleCommand` function, allowing for extended functionality through commands.

These enhancements improve the usability and flexibility of the `ReactNativeScannerView` component, particularly in scenarios requiring precise control over the camera and its features like the flashlight.