### PR TITLE
fix: remove default values for pauseAfterCapture and isActive in ReactNativeScannerView

### DIFF
--- a/ios/ReactNativeScannerView.mm
+++ b/ios/ReactNativeScannerView.mm
@@ -21,8 +21,8 @@ using namespace facebook::react;
     AVCaptureMetadataOutput *_output;
     AVCaptureVideoPreviewLayer *_prevLayer;
     
-    BOOL pauseAfterCapture = NO; // Pause after capturing a barcode / or or not (default: NO)
-    BOOL isActive = YES; // Start the camera when the component is mounted (default: YES)
+    BOOL pauseAfterCapture;
+    BOOL isActive;
 }
 
 + (NSArray *)metadataObjectTypes


### PR DESCRIPTION
This pull request includes changes to the `ReactNativeScannerView` implementation to clean up and simplify the initialization of certain properties.

Codebase simplification:

* [`ios/ReactNativeScannerView.mm`](diffhunk://#diff-a5f5ce6ced49f5f028d4ed29ab8be1d83aa93ed26d13f1f9f94c4db84103ef30L24-R25): Removed default initial values for `pauseAfterCapture` and `isActive` properties to ensure they are initialized explicitly elsewhere in the code.