### PR TITLE
fix: add Swift bridging header support and module name in podspec

### DIFF
--- a/ReactNativeScanner.podspec
+++ b/ReactNativeScanner.podspec
@@ -15,6 +15,18 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
   s.private_header_files = "ios/**/*.h"
+
+  # Enable modules and set the Swift bridging header to allow Swift and Objective-C to interoperate
+  s.pod_target_xcconfig = {
+    # Enables the use of modules (i.e., frameworks) in the generated Xcode project
+    'DEFINES_MODULE' => 'YES',
+    
+    # Sets the name of the generated Swift header for Objective-C code to use
+    'SWIFT_OBJC_INTERFACE_HEADER_NAME' => 'ReactNativeScanner-Swift.h'
+  }
+
+  # The name of the module that will be generated for this pod
+  s.module_name = s.name
   
   # Swift support
   s.swift_version = '5.0'

--- a/ios/CameraViewManager.mm
+++ b/ios/CameraViewManager.mm
@@ -8,8 +8,16 @@
 #import <React/RCTViewManager.h>
 #import <React/RCTBridge.h>
 #import <AVFoundation/AVFoundation.h>
-#import "ReactNativeScanner-Swift.h"
 #import "ReactNativeScanner.h"
+
+// Import the Swift bridging header
+#if __has_include(<ReactNativeScanner/ReactNativeScanner-Swift.h>)
+  // For dynamic frameworks or when installed as a framework
+  #import <ReactNativeScanner/ReactNativeScanner-Swift.h>
+#else
+  // For static libraries or when included directly in the project
+  #import "ReactNativeScanner-Swift.h"
+#endif
 
 @interface ReactNativeScannerViewManager : RCTViewManager
 @end


### PR DESCRIPTION
- The podspec explicitly enables module support
- The bridging header name is explicitly set
- The import statement handles both framework structures
- Works with both static and dynamic linkage