### PR TITLE
fix: camera preview not displaying after view remount

### DIFF
--- a/android/src/main/java/com/pushpendersingh/reactnativescanner/ReactNativeScannerView.kt
+++ b/android/src/main/java/com/pushpendersingh/reactnativescanner/ReactNativeScannerView.kt
@@ -73,6 +73,8 @@ class ReactNativeScannerView(context: Context) : FrameLayout(context) {
         super.onAttachedToWindow()
         // Restart layout callback when view is reattached
         setupLayoutHack()
+        // Rebind the preview view to camera manager when reattached
+        cameraManager?.bindPreviewView(previewView)
     }
 
     override fun onDetachedFromWindow() {


### PR DESCRIPTION
# Fix camera preview not displaying after view remount

## Problem

When `CameraView` component is unmounted and remounted (e.g., navigating away and back to the screen), the camera preview stops displaying even though scanning continues to work.

**Root cause:** When the view is unmounted, `onDetachedFromWindow()` calls `releaseCamera()` which sets `previewView = null`. When the view is remounted, the new `previewView` instance is not automatically bound to the camera manager, so `bindCameraUseCases()` tries to set the surface provider on a null reference:

```kotlin
preview = Preview.Builder().build().also {
    previewView?.let { view ->  // previewView is null!
        it.setSurfaceProvider(view.surfaceProvider)
    }
}
```

This results in a camera that scans barcodes successfully but shows no preview image.

## Solution

Added `bindPreviewView()` call in `onAttachedToWindow()` lifecycle method.

When the view is reattached to the window:
1. `setupLayoutHack()` restarts the layout callback
2. **`bindPreviewView(previewView)`** re-binds the new preview view instance to the camera manager
3. If scanning is active, `bindCameraUseCases()` is called automatically with the correct `previewView` reference

## Changes

```diff
 override fun onAttachedToWindow() {
     super.onAttachedToWindow()
     // Restart layout callback when view is reattached
     setupLayoutHack()
+    // Rebind the preview view to camera manager when reattached
+    cameraManager?.bindPreviewView(previewView)
 }
```

## Testing

Tested on Android with the following scenario:
1. Navigate to screen with `CameraView`
2. Camera preview displays correctly ✅
3. Navigate away from screen
4. Navigate back to screen
5. Camera preview displays correctly ✅ (previously showed black screen)
6. Barcode scanning works correctly ✅

## Benefits

- Camera preview now works correctly after view remount
- Minimal code change - only one line added
- No changes to cleanup logic - `releaseCamera()` still works as intended
- No memory leaks
- Maintains backward compatibility
