### PR TITLE
fix: update video orientation handling in CameraView for session readiness

### DIFF
--- a/ios/CameraView.swift
+++ b/ios/CameraView.swift
@@ -40,6 +40,9 @@ public class CameraView: UIView {
     }
     
     private func setupOrientationObserver() {
+        // Enable device orientation notifications
+        UIDevice.current.beginGeneratingDeviceOrientationNotifications()
+        
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleOrientationChange),
@@ -136,8 +139,9 @@ public class CameraView: UIView {
     }
     
     deinit {
-        // Remove orientation observer
+        // Remove orientation observer and stop generating notifications
         NotificationCenter.default.removeObserver(self, name: UIDevice.orientationDidChangeNotification, object: nil)
+        UIDevice.current.endGeneratingDeviceOrientationNotifications()
         
         // CHANGE: Clear session on teardown to avoid retaining references.
         previewLayer?.session = nil

--- a/ios/CameraView.swift
+++ b/ios/CameraView.swift
@@ -79,20 +79,41 @@ public class CameraView: UIView {
     private func updateVideoOrientation() {
         guard let connection = previewLayer?.connection, connection.isVideoOrientationSupported else { return }
         
-        let orientation = UIDevice.current.orientation
+        let deviceOrientation = UIDevice.current.orientation
         
-        switch orientation {
+        let videoOrientation: AVCaptureVideoOrientation
+        
+        switch deviceOrientation {
         case .portrait:
-            connection.videoOrientation = .portrait
+            videoOrientation = .portrait
         case .landscapeRight:
-            connection.videoOrientation = .landscapeLeft
+            videoOrientation = .landscapeLeft
         case .landscapeLeft:
-            connection.videoOrientation = .landscapeRight
+            videoOrientation = .landscapeRight
         case .portraitUpsideDown:
-            connection.videoOrientation = .portraitUpsideDown
+            videoOrientation = .portraitUpsideDown
         default:
-            break
+            // For .faceUp, .faceDown, .unknown, or during transitions,
+            // fall back to the interface orientation from the window scene
+            if let windowScene = window?.windowScene {
+                switch windowScene.interfaceOrientation {
+                case .portrait:
+                    videoOrientation = .portrait
+                case .landscapeRight:
+                    videoOrientation = .landscapeRight
+                case .landscapeLeft:
+                    videoOrientation = .landscapeLeft
+                case .portraitUpsideDown:
+                    videoOrientation = .portraitUpsideDown
+                default:
+                    videoOrientation = .portrait
+                }
+            } else {
+                videoOrientation = .portrait
+            }
         }
+        
+        connection.videoOrientation = videoOrientation
     }
     
     deinit {

--- a/ios/CameraView.swift
+++ b/ios/CameraView.swift
@@ -48,7 +48,7 @@ public class CameraView: UIView {
                 guard let self = self else { return }
                 if let previewLayer = self.previewLayer {
                     previewLayer.session = session
-                    previewLayer.connection?.videoOrientation = .portrait
+                    self.updateVideoOrientation()
                     print("✅ Preview layer bound to session from onSessionReady callback")
                 } else {
                     print("⚠️ Preview layer missing when session became ready")
@@ -62,7 +62,7 @@ public class CameraView: UIView {
             guard let self = self, let previewLayer = self.previewLayer else { return }
             if let existingSession = existingSession {
                 previewLayer.session = existingSession
-                previewLayer.connection?.videoOrientation = .portrait
+                self.updateVideoOrientation()
                 print("✅ Preview layer bound to existing session")
             }
         }
@@ -73,6 +73,26 @@ public class CameraView: UIView {
     public override func layoutSubviews() {
         super.layoutSubviews()
         previewLayer?.frame = bounds
+        updateVideoOrientation()
+    }
+
+    private func updateVideoOrientation() {
+        guard let connection = previewLayer?.connection, connection.isVideoOrientationSupported else { return }
+        
+        let orientation = UIDevice.current.orientation
+        
+        switch orientation {
+        case .portrait:
+            connection.videoOrientation = .portrait
+        case .landscapeRight:
+            connection.videoOrientation = .landscapeLeft
+        case .landscapeLeft:
+            connection.videoOrientation = .landscapeRight
+        case .portraitUpsideDown:
+            connection.videoOrientation = .portraitUpsideDown
+        default:
+            break
+        }
     }
     
     deinit {


### PR DESCRIPTION
This pull request improves how the camera preview layer's video orientation is managed in the `CameraView` class. Instead of always setting the orientation to portrait, the code now dynamically updates the video orientation based on the device's current orientation. This ensures the camera preview adapts correctly when the device is rotated.

Camera preview orientation improvements:

* Replaced hardcoded `.portrait` video orientation assignments with calls to the new `updateVideoOrientation()` method in session setup callbacks, enabling dynamic orientation updates. (`ios/CameraView.swift`) [[1]](diffhunk://#diff-79fce3f10a41a1d6476c9aa34b9b79ff26aa59a6170f80f3d1a19cfe74fa8584L51-R51) [[2]](diffhunk://#diff-79fce3f10a41a1d6476c9aa34b9b79ff26aa59a6170f80f3d1a19cfe74fa8584L65-R65)
* Added the `updateVideoOrientation()` method, which sets the preview layer's video orientation according to the device's orientation, supporting portrait, landscape left/right, and upside-down modes. (`ios/CameraView.swift`)
* Invoked `updateVideoOrientation()` in `layoutSubviews` to ensure the preview layer orientation updates whenever the view's layout changes, such as during device rotation. (`ios/CameraView.swift`)